### PR TITLE
fix: proper import id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ module.exports = function rawLoaderPlugin({ esbuildOptions }: RawLoaderPluginOpt
         { filter: /.*\?rawbundle$/ },
         async ({ path, resolveDir }) => {
           return {
-            path: path.slice(0, -'?rawbundle'.length),
+            path: resolve(resolveDir, path.slice(0, -'?rawbundle'.length)),
             namespace: 'rawbundle',
             pluginData: {
               resolveDir


### PR DESCRIPTION
Using absolute paths helps esbuild
    understand the files are different even
    if named the same in different paths